### PR TITLE
fix: off-by-one error in no-answer-automarker

### DIFF
--- a/examples/no-answer-automarker.py
+++ b/examples/no-answer-automarker.py
@@ -49,7 +49,7 @@ class Automarker:
     def run(self, username: str, section_id: str, max_mark: int, tasks: list[dict]):
         if self.marks.get(section_id) is None:
             if all(
-                self.answers.get(lookup_key(section_id, t+1)) is None
+                self.answers.get(lookup_key(section_id, t + 1)) is None
                 for t in range(len(tasks))
             ):
                 return {"mark": 0, "feedback": "No answer submitted"}

--- a/examples/no-answer-automarker.py
+++ b/examples/no-answer-automarker.py
@@ -49,7 +49,7 @@ class Automarker:
     def run(self, username: str, section_id: str, max_mark: int, tasks: list[dict]):
         if self.marks.get(section_id) is None:
             if all(
-                self.answers.get(lookup_key(section_id, t)) is None
+                self.answers.get(lookup_key(section_id, t+1)) is None
                 for t in range(len(tasks))
             ):
                 return {"mark": 0, "feedback": "No answer submitted"}


### PR DESCRIPTION
The no answer automarker starts at task with id 0 but the tasks in the exam start with id 1. This leads to sections with only one task being marked as unanswered even if they are answered.